### PR TITLE
dockerでcentosの環境を作る

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM centos:7
+
+# systemd base image
+ENV container docker
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+    systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+    rm -f /lib/systemd/system/multi-user.target.wants/*;\
+    rm -f /etc/systemd/system/*.wants/*;\
+    rm -f /lib/systemd/system/local-fs.target.wants/*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+    rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+    rm -f /lib/systemd/system/basic.target.wants/*;\
+    rm -f /lib/systemd/system/anaconda.target.wants/*;
+VOLUME [ "/sys/fs/cgroup" ]
+
+# クラスタノードの準備
+RUN yum install -y sudo libselinux-utils
+
+# コンテナランタイムの準備
+RUN yum remove docker \
+               docker-client \
+               docker-client-latest \
+               docker-common \
+               docker-selinux \
+               docker-latest \
+               docker-latest-logrotate \
+               docker-logrotate \
+               docker-engine 
+RUN yum install -y yum-utils device-mapper-persistent-data lvm2
+RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+RUN yum makecache fast && yum update -y
+RUN yum install -y docker-ce-18.09.6-3.el7 docker-ce-cli-18.09.6-3.el7 containerd.io
+
+COPY ./config/k8s.conf /etc/sysctl.d/k8s.conf
+COPY ./config/daemon.json /etc/docker/daemon.json
+COPY preparation.sh ./preparation.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # tutorial
 
 Tutorial Contents
+
+## build
+
+docker build --rm -t k8s-practice .
+
+## run 
+
+```
+docker run -d --privileged --name centos k8s-practice /sbin/init
+docker exec -it centos /bin/bash
+```
+
+### execute
+
+```
+sh preparation.sh
+```

--- a/config/daemon.json
+++ b/config/daemon.json
@@ -1,0 +1,8 @@
+{
+  "exec-opts": ["native.cgroupdriver=systemd"],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "100m"
+  },
+  "storage-driver": "overlay2"
+}

--- a/config/k8s.conf
+++ b/config/k8s.conf
@@ -1,0 +1,3 @@
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+vm.swappiness = 0

--- a/preparation.sh
+++ b/preparation.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+sudo swapoff -a
+sudo sysctl --system
+sudo setenforce 0
+sudo sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config
+
+mkdir -p /etc/systemd/system/docker.service.d
+# dockerを再起動
+systemctl enable docker
+systemctl daemon-reload
+systemctl start docker


### PR DESCRIPTION
## 概要

kubeadmを使うためにCentOS7が必要でそのためにdockerで環境を作ろうとした

### 結果

`system start docker`ができない
`dockerd`するとoverlay2がサポートされていないというエラーが出てひとまず断念